### PR TITLE
Removing incorrect cmd line arg count check.

### DIFF
--- a/src/main/java/org/apache/storm/benchmark/tools/BenchmarkRunner.java
+++ b/src/main/java/org/apache/storm/benchmark/tools/BenchmarkRunner.java
@@ -62,13 +62,6 @@ public class BenchmarkRunner {
         CommandLineParser parser = new BasicParser();
         CommandLine cmd = parser.parse(options, args);
 
-        if (cmd.getArgs().length != 2) {
-            usage(options);
-            System.exit(1);
-        }
-
-
-
         String[] argArray = cmd.getArgs();
         runBenchmarks(cmd);
         LOG.info("Benchmark run complete.");


### PR DESCRIPTION
The check is incorrect.
The parser will check anyway so need for this check.
